### PR TITLE
Faraday 2.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,6 @@ group(:rack) do
 end
 
 group(:faraday) do
-  gem 'faraday', '~> 1.3'
+  gem 'faraday', '>= 1.3'
   gem 'faraday_middleware'
 end

--- a/lib/ey-hmac/faraday.rb
+++ b/lib/ey-hmac/faraday.rb
@@ -1,8 +1,8 @@
 require 'ey-hmac'
 require 'faraday'
 
-class Ey::Hmac::Faraday < Faraday::Response::Middleware
-  dependency("ey-hmac")
+class Ey::Hmac::Faraday < Faraday::Middleware
+  dependency("ey-hmac") if respond_to?(:dependency)
 
   attr_reader :key_id, :key_secret, :options
 


### PR DESCRIPTION
Expanding on the work @lanej did a year ago, here's a quick patch for v2.0 support.

That said, given their PR has been sitting around for a year, perhaps this gem is no longer receiving active support? (That's fine, it's how it goes… I'm just pondering writing my own middleware instead, and/or possibly shifting away from Faraday to simplify my project dependencies a touch).