### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/ey-hmac.gemspec
+++ b/ey-hmac.gemspec
@@ -10,7 +10,13 @@ Gem::Specification.new do |gem|
   gem.email         = ['me@joshualane.com']
   gem.description   = 'Lightweight HMAC signing libraries and middleware for Farday and Rack'
   gem.summary       = 'Lightweight HMAC signing libraries and middleware for Farday and Rack'
-  gem.homepage      = ''
+  gem.homepage      = 'https://github.com/lanej/hmac'
+
+  gem.metadata['bug_tracker_uri'] = "#{gem.homepage}/issues"
+  gem.metadata['changelog_uri'] = "#{gem.homepage}/blob/HEAD/CHANGELOG.md"
+  gem.metadata['documentation_uri'] = "https://www.rubydoc.info/gems/#{gem.name}/#{gem.version}"
+  gem.metadata['homepage_uri'] = gem.homepage
+  gem.metadata['source_code_uri'] = "#{gem.homepage}/tree/v#{gem.version}"
 
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }


### PR DESCRIPTION
### Context

It was a little hard to find this repository, given there are no links to it on the [Rubygems project page](https://rubygems.org/gems/ey-hmac).

### Proposed Change

Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

### Consequences

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. After the next release, the URIs will be available on the Rubygems project page, via the Rubygems API, and the `gem` and `bundle` command-line tools.