### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/ey-hmac.gemspec
+++ b/ey-hmac.gemspec
@@ -18,9 +18,11 @@ Gem::Specification.new do |gem|
   gem.metadata['homepage_uri'] = gem.homepage
   gem.metadata['source_code_uri'] = "#{gem.homepage}/tree/v#{gem.version}"
 
-  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |file|
+      file.start_with?(*%w[.git .rubocop Gemfile Rakefile ey-hmac.gemspec spec])
+    end
+  end
   gem.require_paths = ['lib']
   gem.license       = 'MIT'
 


### PR DESCRIPTION
There are several files in the gem package that aren't useful for downstream projects. Removing these files reduces the gem package size from 15K to 10K.

```diff
< .github/workflows/codeql-analysis.yml
< .github/workflows/ruby.yml
< .gitignore
< .rubocop.yml
< .rubocop_todo.yml
  CHANGELOG.md
< Gemfile
  LICENSE.txt
  README.md
< Rakefile
< ey-hmac.gemspec
  lib/ey-hmac.rb
  lib/ey-hmac/adapter.rb
  lib/ey-hmac/adapter/faraday.rb
  lib/ey-hmac/adapter/rack.rb
  lib/ey-hmac/faraday.rb
  lib/ey-hmac/rack.rb
  lib/ey-hmac/version.rb
< spec/faraday_spec.rb
< spec/rack_spec.rb
< spec/shared/authenticated.rb
< spec/spec_helper.rb
```